### PR TITLE
Fix path specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ mainNotes.bib
 /docs/Manifest.toml
 /docs/build/
 /data/graphplot/
+.vscode/

--- a/src/GraphConstraintSearch.jl
+++ b/src/GraphConstraintSearch.jl
@@ -1,7 +1,7 @@
 function searchForSingleConstraint(vertex_nums::Vector{Int}, bit_num::Int, degeneracy::Vector{Int}, dir_path::String, save_path::String)
     all_graph_data_for_degeneracy = []
     for vertex_num in vertex_nums
-        graph_path = dir_path * "graph$(vertex_num).g6"
+        graph_path = joinpath(dir_path, "graph$(vertex_num).g6")
         graph_dict = readGraphDictFile(graph_path)
         gname, candidate, weight = checkSingleConstraint(graph_dict, bit_num, degeneracy)
         isnothing(gname) && continue
@@ -18,7 +18,7 @@ function searchForSingleConstraint(vertex_nums::Vector{Int}, bit_num::Int, degen
             "work_nodes" => candidate
         ))
     end
-    filename = save_path * "$(bit_num)bits_$(degeneracy).json"
+    filename = joinpath(save_path, "$(bit_num)bits_$(degeneracy).json")
     open(filename, "w") do file
         write(file, JSON.json(all_graph_data_for_degeneracy))
     end
@@ -34,7 +34,7 @@ function searchForSingleGate(vertex_nums::Vector{Int}, input_bits::Int, output_b
     degeneracy = genericGate(gate_id, input_bits, output_bits)
     all_graph_data_for_gate = []
     for vertex_num in vertex_nums
-        graph_path = dir_path * "graph$(vertex_num).g6"
+        graph_path = joinpath(dir_path, "graph$(vertex_num).g6")
         graph_dict = readGraphDictFile(graph_path)
         gname, candidate, weight = checkSingleConstraint(graph_dict, input_bits + output_bits, degeneracy)
         isnothing(gname) && continue
@@ -51,7 +51,7 @@ function searchForSingleGate(vertex_nums::Vector{Int}, input_bits::Int, output_b
             "work_nodes" => candidate
         ))
     end
-    filename = save_path * "$(input_bits)in_$(output_bits)out_gate$(gate_id)_$(degeneracy).json"
+    filename = joinpath(save_path, "$(input_bits)in_$(output_bits)out_gate$(gate_id)_$(degeneracy).json")
     open(filename, "w") do file
         write(file, JSON.json(all_graph_data_for_gate))
     end
@@ -65,7 +65,7 @@ function searchForGates(vertex_nums::Vector{Int}, input_bits::Int, output_bits::
         degeneracy = genericGate(gate_id, input_bits, output_bits)
         found = false
         for vertex_num in vertex_nums
-            graph_path = dir_path * "graph$(vertex_num).g6"
+            graph_path = joinpath(dir_path, "graph$(vertex_num).g6")
             graph_dict = readGraphDictFile(graph_path)
             gname, candidate, weight = checkSingleConstraint(graph_dict, input_bits + output_bits, degeneracy)
             isnothing(gname) && continue
@@ -86,7 +86,7 @@ function searchForGates(vertex_nums::Vector{Int}, input_bits::Int, output_bits::
         end
         !found && @info "No suitable graph found for degeneracy $(degeneracy) in Graph $(vertex_nums)"
     end
-    filename = save_path * "$(input_bits)in_$(output_bits)out.json"
+    filename = joinpath(save_path, "$(input_bits)in_$(output_bits)out.json")
     open(filename, "w") do file
         write(file, JSON.json(all_graph_data))
     end
@@ -98,7 +98,7 @@ function searchForAnyConstraint(vertex_nums::Vector{Int}, bit_num::Int, dir_path
     for degeneracy in [collect(s) for s in IterTools.subsets(0:2^bit_num-1) if !isempty(s)]
         found = false
         for vertex_num in vertex_nums
-            graph_path = dir_path * "graph$(vertex_num).g6"
+            graph_path = joinpath(dir_path, "graph$(vertex_num).g6")
             graph_dict = readGraphDictFile(graph_path)
             gname, candidate, weight = checkSingleConstraint(graph_dict, bit_num, degeneracy)
             isnothing(gname) && continue
@@ -118,7 +118,7 @@ function searchForAnyConstraint(vertex_nums::Vector{Int}, bit_num::Int, dir_path
         end
         !found && @info "No suitable graph found for degeneracy $(degeneracy) in Graph $(vertex_nums)."
     end
-    filename = save_path * "$(bit_num)bits_any_constraint.json"
+    filename = joinpath(save_path, "$(bit_num)bits_any_constraint.json")
     open(filename, "w") do file
         write(file, JSON.json(all_graph_data))
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,7 +10,7 @@ end
 
 function plotGraphs(graphs::Dict{String, Graphs.SimpleGraphs.SimpleGraph}, saved_path::String)
     for gname in keys(graphs)
-        draw(Compose.PNG(saved_path * "$gname.png", 16cm, 16cm), gplot(graphs[gname]))
+        draw(Compose.PNG(joinpath(saved_path, "$gname.png"), 16cm, 16cm), gplot(graphs[gname]))
     end
 end
 
@@ -42,7 +42,7 @@ function plotColoredGraph(graph_info::NamedTuple, saved_path::String, name::Stri
               nodefillc = node_colors,
               nodelabel = node_labels
     )
-    draw(Compose.PNG(saved_path * name, 16cm, 16cm), p)
+    draw(Compose.PNG(joinpath(saved_path, name), 16cm, 16cm), p)
 end
 
 function checkGraphMIS(graph_info::NamedTuple)

--- a/test/GraphContraintSearch.jl
+++ b/test/GraphContraintSearch.jl
@@ -1,24 +1,26 @@
+using GadgetSearch, Test
+
 @testset "searchForSingleConstraint" begin
     vertex_num = [3, 4, 5]
     for i in vertex_num
-        path = "../data/graphs/graph$i.g6"
+        path = pkgdir(GadgetSearch, "data", "graphs", "graph$i.g6")
         graph_dict = readGraphDictFile(path)
         checkSingleConstraint(graph_dict, 3, [0])
     end
 end
 
 @testset "searchForAnyConstraint" begin    
-    fn = searchForAnyConstraint([2,3], 2, "../data/graphs/", "../")
+    fn = searchForAnyConstraint([2,3], 2, pkgdir(GadgetSearch, "data", "graphs"), pkgdir(GadgetSearch))
     rm("$fn")
-    fn = searchForSingleConstraint([2,3], 2, [1,2], "../data/graphs/", "../")
+    fn = searchForSingleConstraint([2,3], 2, [1,2], pkgdir(GadgetSearch, "data", "graphs"), pkgdir(GadgetSearch))
     rm("$fn")
-    fn = searchForSingleConstraint([6],3,["111","101","011","000"],"../data/graphs/", "../")
+    fn = searchForSingleConstraint([6],3,["111","101","011","000"],pkgdir(GadgetSearch, "data", "graphs"), pkgdir(GadgetSearch))
     rm("$fn")
 end
 
 @testset "searchForLogicGates" begin
-    fn = searchForSingleGate([6], 2, 2, 2, "../data/graphs/", "../")
+    fn = searchForSingleGate([6], 2, 2, 2, pkgdir(GadgetSearch, "data", "graphs"), pkgdir(GadgetSearch))
     rm("$fn")
-    fn = searchForGates([4], 2, 2, "../data/graphs/", "../")
+    fn = searchForGates([4], 2, 2, pkgdir(GadgetSearch, "data", "graphs"), pkgdir(GadgetSearch))
     rm("$fn")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,5 @@
 @testset "GraphIO" begin
-    path = "../data/graphs/graph2.g6"
+    path = pkgdir(GadgetSearch, "data", "graphs", "graph2.g6")
     graph_dict = readGraphDictFile(path)
     @test readGraphFile(path, 1) == graph_dict["graph1"]
 end
@@ -7,37 +7,37 @@ end
 @testset "graphPlot" begin
     vertex_num = [3]
     for i in vertex_num
-        path = "../data/graphs/graph$i.g6"
+        path = pkgdir(GadgetSearch, "data", "graphs", "graph$i.g6")
         graph_dict = readGraphDictFile(path)
-        if !isdir("../data/graphplot/$(i)vertex/")
-            mkpath("../data/graphplot/$(i)vertex/")
+        if !isdir(pkgdir(GadgetSearch, "data", "graphplot", "$(i)vertex/"))
+            mkpath(pkgdir(GadgetSearch, "data", "graphplot", "$(i)vertex/"))
         end
-        plotGraphs(graph_dict, "../data/graphplot/$(i)vertex/")
+        plotGraphs(graph_dict, pkgdir(GadgetSearch, "data", "graphplot", "$(i)vertex/"))
     end
 end
 
 @testset "loadJSON & locate" begin
-    path = "../datasets/logic_gates/2in_2out.json"
+    path = pkgdir(GadgetSearch, "datasets", "logic_gates", "2in_2out.json")
     data = loadJSONFile(path)
     @test length(data) == 256
     degeneracy = ["0011", "0101", "1010", "1100"]
     g_info = findByDegeneracy(data, degeneracy)
-    plotColoredGraph(g_info, "../data/graphplot/")
-    rm("../data/graphplot/graph.png")
+    plotColoredGraph(g_info, pkgdir(GadgetSearch, "data", "graphplot"))
+    rm(pkgdir(GadgetSearch, "data", "graphplot", "graph.png"))
     _, _, ground_states = checkGraphMIS(g_info)
     @test Set(degeneracy) == Set(ground_states)
 
-    path = "../datasets/any_constraint/2bits_any_constraint.json"
+    path = pkgdir(GadgetSearch, "datasets", "any_constraint", "2bits_any_constraint.json")
     data = loadJSONFile(path)
     @test length(data) == 15
-    path = "../datasets/any_constraint/3bits_any_constraint.json"
+    path = pkgdir(GadgetSearch, "datasets", "any_constraint", "3bits_any_constraint.json")
     data = loadJSONFile(path)
     @test length(data) == 255
     
     degeneracy = ["001", "010", "100", "111"]
     g_info = findByDegeneracy(data, degeneracy)
-    plotColoredGraph(g_info, "../data/graphplot/")
-    rm("../data/graphplot/graph.png")
+    plotColoredGraph(g_info, pkgdir(GadgetSearch, "data", "graphplot"))
+    rm(pkgdir(GadgetSearch, "data", "graphplot", "graph.png"))
     _, _, ground_states = checkGraphMIS(g_info)
     @test Set(degeneracy) == Set(ground_states)
 end


### PR DESCRIPTION
Reason:
- different OS has different ways to specify sub-directories.
- `pkgdir` can resolve a path relative to package correctly.